### PR TITLE
Add printable calendar view

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
+# Calendar Printout
 
+This is a lightweight calendar generator that stores calendars in your browser.
+
+## Usage
+
+1. On the main menu, create a calendar.
+2. Add event lists and items for that calendar.
+3. Use **View Calendar** to pick a month and year and see a printable grid.
+4. Use the **Print** button in the calendar view to open your browser's print dialog.
+
+The layout is grayscale and weekends are lightly shaded for clarity.

--- a/style.css
+++ b/style.css
@@ -11,3 +11,26 @@ body {
 #content {
     padding: 1rem;
 }
+
+/* Calendar view */
+.calendar-controls {
+    margin-bottom: 1rem;
+}
+
+.calendar-grid {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    border: 1px solid #ccc;
+}
+
+.calendar-cell {
+    border: 1px solid #ccc;
+    min-height: 80px;
+    padding: 2px;
+    box-sizing: border-box;
+    font-size: 0.875rem;
+}
+
+.calendar-cell.weekend {
+    background: #f0f0f0;
+}


### PR DESCRIPTION
## Summary
- add month/year picker and print button
- shade weekends and show events in grid
- document basic usage

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686cb7df3f348323ac9061a58b599d7f